### PR TITLE
fix(doc): correct link from dialog to manual bootstraping

### DIFF
--- a/lib/app/docs/plugins/dialog/index-fragment.html
+++ b/lib/app/docs/plugins/dialog/index-fragment.html
@@ -47,7 +47,7 @@
 </code></pre></source-code></code-listing>
 <ol start="2">
 <li>Make sure you use 
-<a href="http://aurelia.io/docs#startup-and-configuration" target="_blank">manual bootstrapping</a>
+<a href="http://aurelia.io/docs/fundamentals/app-configuration-and-startup#bootstrapping-older-browsers" target="_blank">manual bootstrapping</a>
 . In order to do so open your <code>index.html</code> and locate the element with the attribute aurelia-app. Change it to look like this:</li>
 </ol>
 <code-listing heading="index.html">


### PR DESCRIPTION
fixes https://github.com/aurelia/documentation/issues/346