### PR TITLE
Fix: search index was not generated correctly

### DIFF
--- a/lib/processors/article/article-parser.js
+++ b/lib/processors/article/article-parser.js
@@ -161,11 +161,18 @@ function transformMarkdown(content, article, context) {
   let sectionHeader = null;
   let type;
   let section = null;
+  let inParagraph = false;
+  let paragraphText = '';
 
   function addSectionText(text) {
     if (section) {
-      section.text += ' ' + text;
+      section.texts.push(text);
     }
+  }
+
+  function finishSection() {
+    section.text = section.texts.join(' ');
+    delete section.texts;
   }
 
   while (event = walker.next()) {
@@ -179,6 +186,7 @@ function transformMarkdown(content, article, context) {
 
           if(node.level === 2) {
             if (sectionHeader !== null) {
+              finishSection();
               node.insertBefore(wrapInSection(sectionHeader, section, node, headers));
             }
 
@@ -187,7 +195,7 @@ function transformMarkdown(content, article, context) {
               articleHref: article.dest,
               sectionName: sectionName,
               sectionId: slugify(sectionName),
-              text: ''
+              texts: []
             };
 
             context.searchIndex.articles.add(section);
@@ -208,6 +216,21 @@ function transformMarkdown(content, article, context) {
 
           node.insertBefore(htmlBlock);
           node.unlink();
+          break;
+        case 'paragraph':
+          inParagraph = true;
+          paragraphText = '';
+          break;
+        case 'softbreak':
+          if (inParagraph) {
+            paragraphText += ' ';
+          }
+          break;
+        case 'code':
+        case 'text':
+          if (inParagraph) {
+            paragraphText += node.literal;
+          }
           break;
       }
     } else {
@@ -233,10 +256,6 @@ function transformMarkdown(content, article, context) {
           }
           break;
         case 'block_quote':
-          if (node.firstChild && node.firstChild.literal) {
-            addSectionText(node.firstChild.literal);
-          }
-
           let literal = node.firstChild.firstChild.literal;
 
           if(literal) {
@@ -267,22 +286,16 @@ function transformMarkdown(content, article, context) {
             }
           }
           break;
-        case 'item':
-          if (node.firstChild && node.firstChild.firstChild && node.firstChild.firstChild.literal) {
-            addSectionText(node.firstChild.firstChild.literal);
-          }
-          break;
         case 'paragraph':
-        case 'emph':
-          if (node.firstChild && node.firstChild.literal) {
-            addSectionText(node.firstChild.literal);
-          }
+          addSectionText(paragraphText);
+          inParagraph = false;
           break;
       }
     }
   }
 
   if (sectionHeader !== null) {
+    finishSection();
     parsed.appendChild(wrapInSection(sectionHeader, section, node, headers));
   }
 


### PR DESCRIPTION
* Paragraph text was cut off at first `code`, `softbreak`, `strong`, and any character that splits text nodes (eg., single quote).
* Some text was inserted twice

As an example, here’s the broken search index [for the Value Converters documentation](https://aurelia.io/docs/binding/value-converters#value-converters):
<img width="1279" alt="search index" src="https://user-images.githubusercontent.com/4600573/41029364-caec2c0c-697b-11e8-9136-9a6ff046fd6f.png">

Here’s the same section after the fix:
<img width="907" alt="fixed index" src="https://user-images.githubusercontent.com/4600573/41029567-419fb990-697c-11e8-865d-cf2cf93f6451.png">
