### PR TITLE
fix: avoid closing search-panel when user clicks search text

### DIFF
--- a/lib/app/src/resources/search-box.html
+++ b/lib/app/src/resources/search-box.html
@@ -1,5 +1,5 @@
 <template>
-  <header>
+  <header click.trigger="$event.stopPropagation()">
     <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="24px"
       height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
       <g>


### PR DESCRIPTION
This fixes the annoying behaviour that search-panel closes itself when I want to re-position the cursor in some search text.