### PR TITLE
feature(rss): Add persistent rss feed metadata

### DIFF
--- a/lib/templates/index.html
+++ b/lib/templates/index.html
@@ -21,6 +21,7 @@
 
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro:200,400,700" rel="stylesheet">
   <link rel="stylesheet" href="styles/aurelia-docs.css">
+  <link rel="alternate" type="application/rss+xml" title="The official Aurelia blog" href="/blog/rss/index.xml" />
 </head>
 
 <body aurelia-app="main" id="app-host">


### PR DESCRIPTION
This metadata will allow feed readers to automatically detect the feed on the site and suggest subscription. For example, on the Google Chrome RSS Feed Reader extension, it adds the green plus seen here:

![image](https://user-images.githubusercontent.com/3845823/45347625-86e49400-b5e7-11e8-9dfc-d95aa1613ff3.png)

The metadata is added to every page but points to the same rss feed everywhere since we only have the one rss feed.
