### PR TITLE
fix(shell): Hide header buttons on small screens

### DIFF
--- a/lib/app/sass/_shell.scss
+++ b/lib/app/sass/_shell.scss
@@ -53,7 +53,7 @@ header.app-header {
     align-items: center;
     justify-content: center;
     margin: 0 16px;
-    
+
     svg {
       position: relative;
       top: 2px;
@@ -217,5 +217,11 @@ main {
     > .copyright {
       text-align: left;
     }
+  }
+}
+
+@media only screen and (max-width : 500px) {
+  .header-button {
+    display: none;
   }
 }


### PR DESCRIPTION
Maybe not the best fix. I made the header buttons dynamic such that more can be added. At some point they will overflow. But this solves the immediate use case and I'm not sure it's worth the investment to go further.