### PR TITLE
feat(au-sandbox): use intersection-observer to conditionally load sanbox

### DIFF
--- a/lib/app/src/resources/au-sandbox.ts
+++ b/lib/app/src/resources/au-sandbox.ts
@@ -7,7 +7,11 @@ export class AuSandbox {
   @bindable src = '';
   @bindable heading = '';
 
-  constructor(private element: Element) {}
+  private visibilityObserver: IntersectionObserver;
+
+  constructor(private element: Element) {
+    element.innerHTML = `<iframe style="width:100%; height:500px; border:0; border-radius: 4px; border: 2px solid rgb(36, 40, 42); overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`;
+  }
 
   bind() {
     // Ensure we always use CodeMirror for inline demos.
@@ -15,7 +19,35 @@ export class AuSandbox {
     if (this.src.indexOf('codemirror=1') === -1) {
       this.src += '&codemirror=1';
     }
+  }
 
-    this.element.innerHTML = `<iframe src="${this.src}" style="width:100%; height:500px; border:0; border-radius: 4px; border: 2px solid rgb(36, 40, 42); overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`;
+  attached() {
+    const element = this.element;
+    const iframe = element.firstChild as HTMLIFrameElement;
+
+    if (typeof IntersectionObserver !== 'undefined') {
+      let observer = this.visibilityObserver = new IntersectionObserver(records => {
+        records.forEach(record => {
+          if (record.target === element) {
+            if (record.isIntersecting) {
+              iframe.src = this.src;
+            }
+            observer.disconnect();
+            this.visibilityObserver = observer = undefined;
+          }
+        });
+      });
+      observer.observe(element);
+    } else {
+      iframe.src = this.src;
+    }
+  }
+
+  detached() {
+    const observer = this.visibilityObserver;
+    if (observer !== undefined) {
+      observer.disconnect();
+      this.visibilityObserver = undefined;
+    }
   }
 }


### PR DESCRIPTION
@EisenbergEffect 
- move iframe creation to constructor
- start observing in `attached()` and stop in `detached()`
- still do not employ cache (probably will never be reused?)